### PR TITLE
Add ignore-imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,3 +91,26 @@ class A {
   }
 }
 ```
+## Options
+### Ignore import statements
+```
+...,
+  rules: [
+    ...,
+    "blank-line": [true, "ignore-imports"],
+    ...
+  ],
+  ...
+  
+```
+This option disables the rule in import statements. This is helpful if you have multiline named import statements e.g.
+```
+import { A } from "libA";
+import { 
+  firstLongName,
+  secondEvenLongerName,
+  thirdNameThatIsTheLongest
+} from "libB";
+import { C } from "libC";
+```
+By default this is flagged as rule violation.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tslint-plugin-blank-line",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/rules/blankLineRule.ts
+++ b/rules/blankLineRule.ts
@@ -16,7 +16,7 @@ function visitNode(walker: tslint.RuleWalker, sourceFile: ts.SourceFile, prev: t
 
   const source = sourceFile.text.substr(node.getStart(), node.getEnd() - node.getStart());
 
-  if (node.kind !== 1 && prev) {
+  if (node.kind !== ts.SyntaxKind.EndOfFileToken && prev) {
     if (walker.hasOption("ignore-imports") && node.kind === ts.SyntaxKind.ImportDeclaration && prev.kind === ts.SyntaxKind.ImportDeclaration) {
       return;
     }

--- a/rules/blankLineRule.ts
+++ b/rules/blankLineRule.ts
@@ -17,6 +17,9 @@ function visitNode(walker: tslint.RuleWalker, sourceFile: ts.SourceFile, prev: t
   const source = sourceFile.text.substr(node.getStart(), node.getEnd() - node.getStart());
 
   if (node.kind !== 1 && prev) {
+    if (walker.hasOption("ignore-imports") && node.kind === ts.SyntaxKind.ImportDeclaration && prev.kind === ts.SyntaxKind.ImportDeclaration) {
+      return;
+    }
     let nodeBeginPosIncludeComment = node.getStart();
     const comments = ts.getLeadingCommentRanges(sourceFile.text, node.pos) || [];
     if (comments.length > 0) {


### PR DESCRIPTION
Hi,

I've added new option to this rule that ignores multiline import statements. This is useful because it let you keep your imports organized without unnecessary blank lines.

Thanks,
Michał